### PR TITLE
Pin to docker 17.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:dind
+FROM docker:17.12.0-dind
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 # Install iptables, ip6tables, iproute2, and perform glibc install as per:


### PR DESCRIPTION
Fixes build failures caused by the `latest` tag being a moving target.